### PR TITLE
Fix for zend-escaper and zend-http dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "magento/module-checkout": "100.1.*|~100.2",
         "magento/framework": "100.1.*|~101.0",
         "zendframework/zend-stdlib": "2.4.6|~2.7.7",
-        "zendframework/zend-escaper":"~2.4.6",
-        "zendframework/zend-http":"~2.4.6",
+        "zendframework/zend-escaper":"~2.4.6|^2.5",
+        "zendframework/zend-http":"~2.4.6|^2.5.4",
         "webjump/braspagpagador-sdk-adapter":"^0.4.0",
         "luderson/mobiledetectlib": "^3.0"
     },


### PR DESCRIPTION
Since zend-stdlib version upgrade there's a conflict of version dependency for zend-escaper and zend-http, here's the fix.

The new version constraint's were taken from the Zend Framework's composer.json itself.