### PR TITLE
Fixed last_trans_id column length

### DIFF
--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -30,6 +30,10 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $this->upgradeThreeFiveTwo($setup, $context);
         }
 
+        if (version_compare($context->getVersion(), '3.5.3') < 0) {
+            $this->upgradeThreeFiveThree($setup, $context);
+        }
+
         $setup->endSetup();        
     }
 
@@ -135,6 +139,21 @@ class UpgradeSchema implements UpgradeSchemaInterface
             $setup->getIdxName('webjump_braspagpagador_cardtoken', ['customer_id', 'method']),
             ['customer_id', 'method'],
             \Magento\Framework\DB\Adapter\AdapterInterface::INDEX_TYPE_UNIQUE
+        );
+    }
+
+    protected function upgradeThreeFiveThree(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->getConnection()->changeColumn(
+            $setup->getTable('sales_order_payment'),
+            'last_trans_id',
+            'last_trans_id',
+            [
+                'type'     => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                'length'   => 36,
+                'nullable' => true,
+                'comment'  => 'Last Trans Id'
+            ]
         );
     }
 }

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Webjump_BraspagPagador" setup_version="3.5.2">
+    <module name="Webjump_BraspagPagador" setup_version="3.5.3">
         <sequence>
             <module name="Magento_Sales" />
             <module name="Magento_Payment" />


### PR DESCRIPTION
PaymentID returned by Braspag saved in last_trans_id column in sales_order_payment must be 36 characters length.