### PR TITLE
Billet was sending wrong assignor information to Braspag

### DIFF
--- a/Gateway/Transaction/Billet/Config/Config.php
+++ b/Gateway/Transaction/Billet/Config/Config.php
@@ -26,12 +26,22 @@ class Config extends BaseConfig implements ConfigInterface
 		return $this->_getConfig(self::CONFIG_XML_BRASPAG_PAGADOR_BILLET_INSTRUCTIONS);
 	}
 
+    public function getPaymentIdentification()
+    {
+        return $this->_getConfig(self::CONFIG_XML_BRASPAG_PAGADOR_BILLET_IDENTIFICATION);
+    }
+
 	public function getPaymentAssignor()
 	{
 		return $this->_getConfig(self::CONFIG_XML_BRASPAG_PAGADOR_BILLET_ASSIGNOR);
 	}
 
-	public function getExpirationDate()
+    public function getPaymentAssignorAddress()
+    {
+        return $this->_getConfig(self::CONFIG_XML_BRASPAG_PAGADOR_BILLET_ASSIGNOR_ADDRESS);
+    }
+
+    public function getExpirationDate()
 	{
 		return $this->getDateTime()->gmDate(self::DATE_FORMAT, strtotime(sprintf(self::DAY_FORMAT, (int) $this->_getConfig(self::CONFIG_XML_BRASPAG_PAGADOR_BILLET_EXPIRATION_DATE))));
 	}

--- a/Gateway/Transaction/Billet/Config/ConfigInterface.php
+++ b/Gateway/Transaction/Billet/Config/ConfigInterface.php
@@ -15,7 +15,9 @@ interface ConfigInterface
 {
 	const CONFIG_XML_BRASPAG_PAGADOR_BILLET_DEMONSTRATIVE = 'payment/braspag_pagador_billet/demonstrative';
 	const CONFIG_XML_BRASPAG_PAGADOR_BILLET_INSTRUCTIONS = 'payment/braspag_pagador_billet/instructions';
+    const CONFIG_XML_BRASPAG_PAGADOR_BILLET_IDENTIFICATION = 'payment/braspag_pagador_billet/identification';
 	const CONFIG_XML_BRASPAG_PAGADOR_BILLET_ASSIGNOR = 'payment/braspag_pagador_billet/assignor';
+    const CONFIG_XML_BRASPAG_PAGADOR_BILLET_ASSIGNOR_ADDRESS = 'payment/braspag_pagador_billet/assignor_address';
 	const CONFIG_XML_BRASPAG_PAGADOR_BILLET_EXPIRATION_DATE = 'payment/braspag_pagador_billet/expiration_days';
 	const CONFIG_XML_BRASPAG_PAGADOR_BILLET_PROVIDER = 'payment/braspag_pagador_billet/types';
     const CONFIG_XML_BRASPAG_PAGADOR_CUSTOMER_ADDRESS_STREET_ATTRIBUTE = 'payment/braspag_pagador_customer_address/street_attribute';
@@ -33,7 +35,11 @@ interface ConfigInterface
 
 	public function getPaymentInstructions();
 
+	public function getPaymentIdentification();
+
 	public function getPaymentAssignor();
+
+    public function getPaymentAssignorAddress();
 
 	public function getExpirationDate();
 

--- a/Gateway/Transaction/Billet/Resource/Send/Request.php
+++ b/Gateway/Transaction/Billet/Resource/Send/Request.php
@@ -212,9 +212,7 @@ class Request implements BraspagMagentoRequestInterface, BraspaglibRequestInterf
      */
     public function getPaymentAddress()
 	{
-		$address = $this->getBillingAddress();
-
-		return sprintf("%s %s %s/%s - %s", $this->getCustomerAddressStreet(), $this->getCustomerAddressNumber(), $address->getCity(), $address->getRegionCode(), $address->getPostcode());
+        return $this->getConfig()->getPaymentAssignorAddress();
 	}
 
     /**
@@ -262,7 +260,7 @@ class Request implements BraspagMagentoRequestInterface, BraspaglibRequestInterf
      */
     public function getPaymentIdentification()
 	{
-		return $this->getOrderAdapter()->getOrderIncrementId();
+		return $this->getConfig()->getPaymentIdentification();
 	}
 
     /**

--- a/etc/adminhtml/system/transaction/billet.xml
+++ b/etc/adminhtml/system/transaction/billet.xml
@@ -51,6 +51,22 @@
                 <field id="active">1</field>
             </depends>
 	    </field>
+		<field id="assignor_address" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+			<label>Assignor Address</label>
+			<comment />
+			<config_path>payment/braspag_pagador_billet/assignor_address</config_path>
+			<depends>
+				<field id="active">1</field>
+			</depends>
+		</field>
+		<field id="identification" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
+			<label>Identification</label>
+			<comment />
+			<config_path>payment/braspag_pagador_billet/identification</config_path>
+			<depends>
+				<field id="active">1</field>
+			</depends>
+		</field>
 	    <field id="expiration_days" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="20" translate="label" type="text">
 	        <label>Expirations Day</label>
 	        <comment />

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -1,1 +1,2 @@
 "Credit Card Number","Credit Card Number"
+"Identification","Identificação"


### PR DESCRIPTION
Estava sendo enviado informações incorretas para a geração de boleto, sendo elas:

- No campo Payment.Identification estava sendo enviado o increment_id no lugar do CNPJ do cedente (Criada configuração para esse campo)
- No campo Payment.Address estava sendo enviado o endereço do customer no lugar do endereço do cedente (Criada configuração para esse campo)