### PR TITLE
Customer Identity Type fix validation

### DIFF
--- a/Gateway/Transaction/Billet/Resource/Send/Request.php
+++ b/Gateway/Transaction/Billet/Resource/Send/Request.php
@@ -113,8 +113,8 @@ class Request implements BraspagMagentoRequestInterface, BraspaglibRequestInterf
      */
     public function getCustomerIdentityType()
     {
-        $identity = (int) preg_replace('/[^0-9]/','', $this->getCustomerIdentity());
-        return (strlen($identity) === 14) ? 'CNPJ' : 'CPF';
+        $identity = (string) preg_replace('/[^0-9]/','', $this->getCustomerIdentity());
+        return (strlen($identity) > 11) ? 'CNPJ' : 'CPF';
     }
 
     /**

--- a/Gateway/Transaction/CreditCard/Resource/Authorize/Request.php
+++ b/Gateway/Transaction/CreditCard/Resource/Authorize/Request.php
@@ -137,8 +137,8 @@ class Request implements BraspaglibRequestInterface, RequestInterface
      */
     public function getCustomerIdentityType()
     {
-        $identity = (int) preg_replace('/[^0-9]/','', $this->getCustomerIdentity());
-        return (strlen($identity) === 14) ? 'CNPJ' : 'CPF';
+        $identity = (string) preg_replace('/[^0-9]/','', $this->getCustomerIdentity());
+        return (strlen($identity) > 11) ? 'CNPJ' : 'CPF';
     }
 
     /**


### PR DESCRIPTION
Atualmente a validação remove os 0 (zeros) à esquerda, devido a conversão do valor para **inteiro**.
Em seguida compara se o tamanho do resultado é igual a 14. Porém, no caso de entrar um CNPJ com 0 (zero) à esquerda, o tamanho é 13, fazendo com que a função retorne, assim, CPF.