### PR TITLE
Itau 2 Provider

### DIFF
--- a/Model/Source/BilletTypes.php
+++ b/Model/Source/BilletTypes.php
@@ -24,6 +24,7 @@ class BilletTypes extends \Magento\Payment\Model\Source\Cctype
             'BancoDoBrasil',
             'CitiBank',
             'ItauShopline',
+            'Itau2',
             'Brb',
             'Caixa',
             'Santander',

--- a/etc/adminhtml/system/customer.xml
+++ b/etc/adminhtml/system/customer.xml
@@ -8,6 +8,11 @@
 <include xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_include.xsd">
     <group id="webjump_braspag_pagador_customer" translate="label comment" showInDefault="1" showInWebsite="1" showInStore="1" sortOrder="20">
         <label>Customer Config</label>
+        <field id="customer_identity_attribute_code" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="30" translate="label" type="text">
+            <label>Customer Identity (CPF/CNPJ) Attribute</label>
+            <config_path>payment/braspag_pagador_creditcard/customer_identity_attribute_code</config_path>
+            <comment>object from \Magento\Quote\Model\Quote</comment>
+        </field>
         <frontend_model>Webjump\BraspagPagador\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
         <include path="Webjump_BraspagPagador::system/customer/address.xml"/>
     </group>

--- a/etc/adminhtml/system/transaction/creditcard.xml
+++ b/etc/adminhtml/system/transaction/creditcard.xml
@@ -23,11 +23,6 @@
             <comment>If null default 2</comment>
             <config_path>payment/braspag_pagador_creditcard/decimal_grand_total</config_path>
         </field>
-        <field id="customer_identity_attribute_code" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="30" translate="label" type="text">
-            <label>Customer Identity (CPF/CNPJ) Attribute</label>
-            <config_path>payment/braspag_pagador_creditcard/customer_identity_attribute_code</config_path>
-            <comment>object from \Magento\Quote\Model\Quote</comment>
-        </field>
         <field id="payment_action" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="40" translate="label" type="select">
             <label>Payment Action</label>
             <comment />

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -354,7 +354,7 @@
         </arguments>
     </virtualType>
 
-    <virtualType name="BraspagTransactionDebitCardOrderRequestConfig" type="">
+    <virtualType name="BraspagTransactionDebitCardOrderRequestConfig" type="Magento\Framework\App\Config">
         <arguments>
             <argument name="config" xsi:type="object">Magento\Framework\App\Config</argument>
         </arguments>

--- a/etc/payment.xml
+++ b/etc/payment.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <payment xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Payment:etc/payment.xsd">
-    
+
     <methods>
         <method name="braspag_pagador_billet">
             <allow_multiple_address>1</allow_multiple_address>
@@ -9,7 +9,7 @@
             <allow_multiple_address>1</allow_multiple_address>
         </method>
     </methods>
-    
+
     <credit_cards>
         <type id="Simulado" order="0">
             <label>Simulado*</label>
@@ -112,6 +112,9 @@
         <type id="ItauShopline" order="31">
             <label>Itau</label>
         </type>
+        <type id="Itau2" order="31">
+            <label>Itau 2</label>
+        </type>
         <type id="Brb" order="32">
             <label>Brb</label>
         </type>
@@ -124,7 +127,7 @@
         <type id="HSBC" order="35">
             <label>HSBC</label>
         </type>
-        
+
         <!-- Debit Card -->
         <type id="Cielo" order="1">
             <label>Cielo</label>


### PR DESCRIPTION
+ Included new provider for billet payment method (Itau2)
~ Changed the location of "Customer Identity" configuration from the Credit Card to the Customer Configuration (Admin position only, paths kept)
* Bugfix: Added a value to the "type" property on the "BraspagTransactionDebitCardOrderRequestConfig" virtual type so we don't get errors when compiling.