### PR TITLE
Fix decimal places bug in billet amount grand total

### DIFF
--- a/Gateway/Transaction/Billet/Resource/Send/Request.php
+++ b/Gateway/Transaction/Billet/Resource/Send/Request.php
@@ -203,7 +203,7 @@ class Request implements BraspagMagentoRequestInterface, BraspaglibRequestInterf
      */
     public function getPaymentAmount()
 	{
-		$amount = (float) $this->getOrderAdapter()->getGrandTotalAmount() * 100;
+		$amount = (float) round($this->getOrderAdapter()->getGrandTotalAmount(), 2) * 100;
 		return str_replace('.', '', $amount);
 	}
 


### PR DESCRIPTION
O Magento permite totais com mais de duas casas decimais, porém, a Braspag não considera, já que o _amount_ é enviado sem pontuação.
Quando enviado um _Grand Total_ com mais de duas casas decimais, o _amount_ transforma para milhar.
Segue em anexo exemplo de um pedido no Magento e seu respectivo boleto gerado.

![ev_order_magento](https://user-images.githubusercontent.com/16033909/37617550-3acb044e-2b92-11e8-995f-c78bef7be848.png)

![ev_billet_braspag](https://user-images.githubusercontent.com/16033909/37617570-4884fcde-2b92-11e8-9d53-fe5507f40274.png)
