### PR TITLE
Disable tokens generated by braspag module instead of deleting them - Feature/pactv 774

### DIFF
--- a/Api/CardTokenManagerInterface.php
+++ b/Api/CardTokenManagerInterface.php
@@ -10,7 +10,16 @@
 
 namespace Webjump\BraspagPagador\Api;
 
+use Webjump\BraspagPagador\Api\Data\CardTokenInterface;
+
 interface CardTokenManagerInterface
 {
     public function registerCardToken($customerId, $paymentMethod, $response);
+
+    /**
+     * @param $cardToken
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function disable(CardTokenInterface  $cardToken);
 }

--- a/Api/CardTokenRepositoryInterface.php
+++ b/Api/CardTokenRepositoryInterface.php
@@ -49,4 +49,11 @@ interface CardTokenRepositoryInterface
      * @throws \Magento\Framework\Exception\CouldNotDeleteException
      */
     public function delete(CardTokenInterface  $cardToken);
+
+    /**
+     * @param $cardToken
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function disable(CardTokenInterface  $cardToken);
 }

--- a/Api/CardTokenRepositoryInterface.php
+++ b/Api/CardTokenRepositoryInterface.php
@@ -50,10 +50,4 @@ interface CardTokenRepositoryInterface
      */
     public function delete(CardTokenInterface  $cardToken);
 
-    /**
-     * @param $cardToken
-     *
-     * @throws \Magento\Framework\Exception\LocalizedException
-     */
-    public function disable(CardTokenInterface  $cardToken);
 }

--- a/Api/Data/CardTokenInterface.php
+++ b/Api/Data/CardTokenInterface.php
@@ -31,6 +31,8 @@ interface CardTokenInterface
 
     const METHOD = 'method';
 
+    const MASK  =  'mask';
+
     public function getId();
 
     public function getAlias();
@@ -49,6 +51,8 @@ interface CardTokenInterface
 
     public function getMethod();
 
+    public function getMask();
+
     public function setId($id);
 
     public function setAlias($alias);
@@ -66,5 +70,7 @@ interface CardTokenInterface
     public function setProvider($provider);
 
     public function setMethod($method);
+
+    public function setMask($mask);
 }
 

--- a/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandler.php
+++ b/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandler.php
@@ -9,7 +9,7 @@ use Webjump\BraspagPagador\Api\CardTokenRepositoryInterface;
 use Magento\Framework\Event\ManagerInterface;
 use Magento\Framework\DataObject;
 use Magento\Framework\Api\SearchCriteriaBuilder;
-
+use Webjump\BraspagPagador\Api\CardTokenManagerInterface;
 
 /**
  * Braspag Transaction CreditCard Authorize Response Handler
@@ -26,6 +26,11 @@ class CardTokenHandler extends AbstractHandler implements HandlerInterface
      * @var
      */
     protected $cardTokenRepository;
+
+    /**
+     * @var
+     */
+    protected $cardTokenManager;
 
     /**
      * @var
@@ -49,16 +54,19 @@ class CardTokenHandler extends AbstractHandler implements HandlerInterface
      * @param CardTokenRepositoryInterface $cardTokenRepository
      * @param ManagerInterface             $eventManager
      * @param SearchCriteriaBuilder        $searchCriteriaBuilder
+     * @param CardTokenManagerInterface    $cardTokenManager
      */
     public function __construct(
         CardTokenRepositoryInterface $cardTokenRepository,
         ManagerInterface $eventManager,
-        SearchCriteriaBuilder $searchCriteriaBuilder
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        CardTokenManagerInterface $cardTokenManager
     )
     {
         $this->setCardTokenRepository($cardTokenRepository);
         $this->setEventManager($eventManager);
         $this->setSearchCriteriaBuilder($searchCriteriaBuilder);
+        $this->setCardTokenManager($cardTokenManager);
     }
 
     /**
@@ -98,7 +106,7 @@ class CardTokenHandler extends AbstractHandler implements HandlerInterface
         $searchResult = $this->getCardTokenRepository()->getList($searchCriteria);
 
         foreach ($searchResult->getItems() as $item) {
-            $this->getCardTokenRepository()->disable($item);
+            $this->getCardTokenManager()->disable($item);
         }
 
         $data = new DataObject([
@@ -177,4 +185,22 @@ class CardTokenHandler extends AbstractHandler implements HandlerInterface
 
         return $this;
     }
+
+    /**
+     * @param mixed $cardTokenManager
+     */
+    public function setCardTokenManager($cardTokenManager)
+    {
+        $this->cardTokenManager = $cardTokenManager;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCardTokenManager()
+    {
+        return $this->cardTokenManager;
+    }
+
+
 }

--- a/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandler.php
+++ b/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandler.php
@@ -91,8 +91,6 @@ class CardTokenHandler extends AbstractHandler implements HandlerInterface
         $searchCriteriaBuilder = $this->getSearchCriteriaBuilder();
         $searchCriteriaBuilder->addFilter('method', $payment->getMethod());
         $searchCriteriaBuilder->addFilter('customer_id', $payment->getOrder()->getCustomerId());
-        $searchCriteriaBuilder->addFilter('brand', $response->getPaymentCardBrand());
-        $searchCriteriaBuilder->addFilter('alias', $response->getPaymentCardToken());
         $searchCriteria = $searchCriteriaBuilder->create();
 
         $searchResult = $this->getCardTokenRepository()->getList($searchCriteria);

--- a/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandler.php
+++ b/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandler.php
@@ -91,12 +91,14 @@ class CardTokenHandler extends AbstractHandler implements HandlerInterface
         $searchCriteriaBuilder = $this->getSearchCriteriaBuilder();
         $searchCriteriaBuilder->addFilter('method', $payment->getMethod());
         $searchCriteriaBuilder->addFilter('customer_id', $payment->getOrder()->getCustomerId());
+        $searchCriteriaBuilder->addFilter('brand', $response->getPaymentCardBrand());
+        $searchCriteriaBuilder->addFilter('alias', $response->getPaymentCardToken());
         $searchCriteria = $searchCriteriaBuilder->create();
 
         $searchResult = $this->getCardTokenRepository()->getList($searchCriteria);
 
         foreach ($searchResult->getItems() as $item) {
-            $this->getCardTokenRepository()->delete($item);
+            $this->getCardTokenRepository()->disable($item);
         }
 
         $data = new DataObject([
@@ -105,6 +107,7 @@ class CardTokenHandler extends AbstractHandler implements HandlerInterface
             'provider' => $response->getPaymentCardProvider(),
             'brand' => $response->getPaymentCardBrand(),
             'method' => $payment->getMethod(),
+            'mask'   => $response->getPaymentAuthorizationCode()
         ]);
 
         $this->getEventManager()->dispatch(

--- a/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandler.php
+++ b/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandler.php
@@ -91,6 +91,7 @@ class CardTokenHandler extends AbstractHandler implements HandlerInterface
         $searchCriteriaBuilder = $this->getSearchCriteriaBuilder();
         $searchCriteriaBuilder->addFilter('method', $payment->getMethod());
         $searchCriteriaBuilder->addFilter('customer_id', $payment->getOrder()->getCustomerId());
+        $searchCriteriaBuilder->addFilter('brand', $response->getPaymentCardBrand());
         $searchCriteria = $searchCriteriaBuilder->create();
 
         $searchResult = $this->getCardTokenRepository()->getList($searchCriteria);

--- a/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandler.php
+++ b/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandler.php
@@ -88,6 +88,7 @@ class CardTokenHandler extends AbstractHandler implements HandlerInterface
         if ($cardToken = $this->getCardTokenRepository()->get($response->getPaymentCardToken())) {
             return $cardToken;
         }
+
         $searchCriteriaBuilder = $this->getSearchCriteriaBuilder();
         $searchCriteriaBuilder->addFilter('method', $payment->getMethod());
         $searchCriteriaBuilder->addFilter('customer_id', $payment->getOrder()->getCustomerId());

--- a/Model/CardToken.php
+++ b/Model/CardToken.php
@@ -60,6 +60,11 @@ class CardToken extends \Magento\Framework\Model\AbstractModel implements \Webju
         return $this->getData(self::METHOD);
     }
 
+    public function getMask()
+    {
+        return $this->getData(self::MASK);
+    }
+
     public function setId($id)
     {
         return $this->setData(self::ENTITY_ID, $id);
@@ -118,5 +123,10 @@ class CardToken extends \Magento\Framework\Model\AbstractModel implements \Webju
     public function setMethod($method)
     {
         return $this->setData(self::METHOD, $method);
+    }
+
+    public function setMask($mask)
+    {
+        return $this->setData(self::MASK, $mask);
     }
 }

--- a/Model/CardTokenManager.php
+++ b/Model/CardTokenManager.php
@@ -60,12 +60,14 @@ class CardTokenManager implements CardTokenManagerInterface
         $searchCriteriaBuilder = $this->getSearchCriteriaBuilder();
         $searchCriteriaBuilder->addFilter('method', $paymentMethod);
         $searchCriteriaBuilder->addFilter('customer_id', $customerId);
+        $searchCriteriaBuilder->addFilter('brand', $response->getPaymentCardBrand());
+        $searchCriteriaBuilder->addFilter('alias', $response->getPaymentCardToken());
         $searchCriteria = $searchCriteriaBuilder->create();
 
         $searchResult = $this->getCardTokenRepository()->getList($searchCriteria);
 
         foreach ($searchResult->getItems() as $item) {
-            $this->deleteCardToken($item);
+            $this->disableCardToken($item);
         }
 
         $data = new DataObject([
@@ -74,6 +76,7 @@ class CardTokenManager implements CardTokenManagerInterface
             'provider' => $response->getPaymentCardProvider(),
             'brand' => $response->getPaymentCardBrand(),
             'method' => $paymentMethod,
+            'mask'   => $response->getPaymentAuthorizationCode()
         ]);
 
         $cardToken = $this->getCardTokenRepository()->create($data->toArray());
@@ -86,6 +89,12 @@ class CardTokenManager implements CardTokenManagerInterface
     protected function deleteCardToken($cardToken)
     {
         $this->getCardTokenRepository()->delete($cardToken);
+    }
+
+
+    protected function disableCardToken($cardToken)
+    {
+        $this->getCardTokenRepository()->disable($cardToken);
     }
 
     /**

--- a/Model/CardTokenManager.php
+++ b/Model/CardTokenManager.php
@@ -60,6 +60,7 @@ class CardTokenManager implements CardTokenManagerInterface
         $searchCriteriaBuilder = $this->getSearchCriteriaBuilder();
         $searchCriteriaBuilder->addFilter('method', $paymentMethod);
         $searchCriteriaBuilder->addFilter('customer_id', $customerId);
+        $searchCriteriaBuilder->addFilter('brand', $response->getPaymentCardBrand());
         $searchCriteria = $searchCriteriaBuilder->create();
 
         $searchResult = $this->getCardTokenRepository()->getList($searchCriteria);

--- a/Model/CardTokenManager.php
+++ b/Model/CardTokenManager.php
@@ -15,6 +15,7 @@ use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface;
 use Webjump\BraspagPagador\Api\CardTokenManagerInterface;
 use Webjump\BraspagPagador\Api\CardTokenRepositoryInterface;
+use Webjump\BraspagPagador\Api\Data\CardTokenInterface;
 
 class CardTokenManager implements CardTokenManagerInterface
 {
@@ -66,7 +67,7 @@ class CardTokenManager implements CardTokenManagerInterface
         $searchResult = $this->getCardTokenRepository()->getList($searchCriteria);
 
         foreach ($searchResult->getItems() as $item) {
-            $this->disableCardToken($item);
+            $this->disable($item);
         }
 
         $data = new DataObject([
@@ -90,11 +91,25 @@ class CardTokenManager implements CardTokenManagerInterface
         $this->getCardTokenRepository()->delete($cardToken);
     }
 
-
-    protected function disableCardToken($cardToken)
+    /**
+     * @param $cardToken
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function disable(CardTokenInterface  $cardToken)
     {
-        $this->getCardTokenRepository()->disable($cardToken);
+        try {
+            $cardTokenId = $cardToken->getId();
+            if (!empty($cardTokenId)) {
+                $cardToken->setActive(0);
+                $this->getCardTokenRepository()->save($cardToken);
+            }
+
+        } catch (Exception $e) {
+            throw new \Magento\Framework\Exception\LocalizedException(__('Unable to disable Card Token'));
+        }
     }
+
 
     /**
      * @return mixed

--- a/Model/CardTokenManager.php
+++ b/Model/CardTokenManager.php
@@ -60,8 +60,6 @@ class CardTokenManager implements CardTokenManagerInterface
         $searchCriteriaBuilder = $this->getSearchCriteriaBuilder();
         $searchCriteriaBuilder->addFilter('method', $paymentMethod);
         $searchCriteriaBuilder->addFilter('customer_id', $customerId);
-        $searchCriteriaBuilder->addFilter('brand', $response->getPaymentCardBrand());
-        $searchCriteriaBuilder->addFilter('alias', $response->getPaymentCardToken());
         $searchCriteria = $searchCriteriaBuilder->create();
 
         $searchResult = $this->getCardTokenRepository()->getList($searchCriteria);

--- a/Model/CardTokenRepository.php
+++ b/Model/CardTokenRepository.php
@@ -153,6 +153,24 @@ class CardTokenRepository implements CardTokenRepositoryInterface
     }
 
     /**
+     * @param $cardToken
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function disable(CardTokenInterface  $cardToken)
+    {
+        try {
+            $cardToken = $this->getCardTokenRepository()->get($cardToken->getToken());
+            if (!isset($cardToken)) {
+                $cardToken->setActive(false);
+            }
+
+        } catch (Exception $e) {
+            throw new \Magento\Framework\Exception\LocalizedException(__('Unable to disable Card Token'));
+        }
+    }
+
+    /**
      * @param SearchCriteriaInterface $searchCriteria
      *
      * @return mixed

--- a/Model/CardTokenRepository.php
+++ b/Model/CardTokenRepository.php
@@ -153,25 +153,6 @@ class CardTokenRepository implements CardTokenRepositoryInterface
     }
 
     /**
-     * @param $cardToken
-     *
-     * @throws \Magento\Framework\Exception\LocalizedException
-     */
-    public function disable(CardTokenInterface  $cardToken)
-    {
-        try {
-            $cardTokenId = $cardToken->getId();
-            if (!empty($cardTokenId)) {
-                $cardToken->setActive(0);
-                $this->save($cardToken);
-            }
-
-        } catch (Exception $e) {
-            throw new \Magento\Framework\Exception\LocalizedException(__('Unable to disable Card Token'));
-        }
-    }
-
-    /**
      * @param SearchCriteriaInterface $searchCriteria
      *
      * @return mixed

--- a/Model/CardTokenRepository.php
+++ b/Model/CardTokenRepository.php
@@ -160,9 +160,10 @@ class CardTokenRepository implements CardTokenRepositoryInterface
     public function disable(CardTokenInterface  $cardToken)
     {
         try {
-            $cardToken = $this->getCardTokenRepository()->get($cardToken->getToken());
-            if (!isset($cardToken)) {
-                $cardToken->setActive(false);
+            $cardTokenId = $cardToken->getId();
+            if (!empty($cardTokenId)) {
+                $cardToken->setActive(0);
+                $this->save($cardToken);
             }
 
         } catch (Exception $e) {

--- a/Model/CardTokenRepository.php
+++ b/Model/CardTokenRepository.php
@@ -91,7 +91,7 @@ class CardTokenRepository implements CardTokenRepositoryInterface
             $cardToken = $this->getCardTokenFactory()->create();
             $cardToken->load($token, CardTokenInterface::TOKEN);
 
-            if (!$cardTokenId = $cardToken->getId()) {
+            if (!$cardToken->getId()) {
                 return false;
             }
 

--- a/Test/Unit/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandlerTest.php
+++ b/Test/Unit/Gateway/Transaction/CreditCard/Resource/Authorize/Response/CardTokenHandlerTest.php
@@ -93,7 +93,9 @@ class CardTokenHandlerTest extends \PHPUnit\Framework\TestCase
             'token' => '6e1bf77a-b28b-4660-b14f-455e2a1c95e9',
             'provider' => 'Cielo',
             'brand' => 'Visa',
+            'mask'  => '364135'
         ]);
+
 
         $this->cardTokenRepositoryMock
             ->expects($this->once())
@@ -125,9 +127,13 @@ class CardTokenHandlerTest extends \PHPUnit\Framework\TestCase
             ->method('getPaymentCardProvider')
             ->will($this->returnValue('Cielo'));
 
-        $this->responseMock->expects($this->once())
+        $this->responseMock->expects($this->exactly(2))
             ->method('getPaymentCardBrand')
             ->will($this->returnValue('Visa'));
+
+        $this->responseMock->expects($this->once())
+            ->method('getPaymentAuthorizationCode')
+            ->will($this->returnValue('364135'));
 
         $paymentMock = $this->getMockBuilder('Magento\Sales\Model\Order\Payment')
             ->disableOriginalConstructor()

--- a/Test/Unit/bootstrap.php
+++ b/Test/Unit/bootstrap.php
@@ -12,14 +12,17 @@ require_once realpath(__DIR__ . '/../../vendor/autoload.php');
 /**
  * @SuppressWarnings(PHPMD.ShortMethodName)
  */
-function __()
-{
-    $argc = func_get_args();
+if (function_exists('boostrap')) {
 
-    $text = array_shift($argc);
-    if (!empty($argc) && is_array($argc[0])) {
-        $argc = $argc[0];
+    function __()
+    {
+        $argc = func_get_args();
+
+        $text = array_shift($argc);
+        if (!empty($argc) && is_array($argc[0])) {
+            $argc = $argc[0];
+        }
+
+        return new \Magento\Framework\Phrase($text, $argc);
     }
-
-    return new \Magento\Framework\Phrase($text, $argc);
 }

--- a/Test/Unit/bootstrap.php
+++ b/Test/Unit/bootstrap.php
@@ -12,17 +12,14 @@ require_once realpath(__DIR__ . '/../../vendor/autoload.php');
 /**
  * @SuppressWarnings(PHPMD.ShortMethodName)
  */
-if (function_exists('boostrap')) {
+function __()
+{
+    $argc = func_get_args();
 
-    function __()
-    {
-        $argc = func_get_args();
-
-        $text = array_shift($argc);
-        if (!empty($argc) && is_array($argc[0])) {
-            $argc = $argc[0];
-        }
-
-        return new \Magento\Framework\Phrase($text, $argc);
+    $text = array_shift($argc);
+    if (!empty($argc) && is_array($argc[0])) {
+        $argc = $argc[0];
     }
+
+    return new \Magento\Framework\Phrase($text, $argc);
 }


### PR DESCRIPTION
Braspag Module was deleting tokens that already existed when create new orders and generate  new  tokens with same credit card.This was breaking the sequence of  creating new orders programatically in Magento 2.When we create two orders in Magento 2, and then try to generate two more orders based on this orders  programatically with cron, the cron could not generated the order of the first one.Because, Braspag Module was deleting the token of the first order. 