### PR TITLE
Change return array to return mixed because is causing errors

### DIFF
--- a/Api/InstallmentsInterface.php
+++ b/Api/InstallmentsInterface.php
@@ -6,7 +6,7 @@ namespace Webjump\BraspagPagador\Api;
 interface InstallmentsInterface
 {
     /**
-     * @return array
+     * @return mixed
      */
     public function getInstallments();
 }


### PR DESCRIPTION
Resolvido o problema ao usar o swagger com o módulo Braspag Pagador.

![Erro](https://serving.photos.photobox.com/5805606853bfef0ed379b09b8e3e64587db65fd787c603b87a2259f025376de4dd501aa9.jpg)