### PR TITLE
Add a lookup to customer identity to verify the attribute in quote billing address and if it fails in quote

### DIFF
--- a/Gateway/Transaction/Billet/Resource/Send/Request.php
+++ b/Gateway/Transaction/Billet/Resource/Send/Request.php
@@ -105,7 +105,8 @@ class Request implements BraspagMagentoRequestInterface, BraspaglibRequestInterf
      */
     public function getCustomerIdentity()
     {
-        return $this->getQuote()->getData($this->getConfig()->getIdentityAttributeCode());
+        $attribute = $this->getConfig()->getIdentityAttributeCode();
+        return $this->getQuote()->getBillingAddress()->getData($attribute) ?: $this->getQuote()->getData($attribute);
     }
 
     /**

--- a/Gateway/Transaction/CreditCard/Resource/Authorize/Request.php
+++ b/Gateway/Transaction/CreditCard/Resource/Authorize/Request.php
@@ -137,7 +137,8 @@ class Request implements BraspaglibRequestInterface, RequestInterface
      */
     public function getCustomerIdentity()
     {
-        return $this->getQuote()->getData($this->getConfig()->getIdentityAttributeCode());
+        $attribute = $this->getConfig()->getIdentityAttributeCode();
+        return $this->getQuote()->getBillingAddress()->getData($attribute) ?: $this->getQuote()->getData($attribute);
     }
 
     /**

--- a/etc/adminhtml/system/customer.xml
+++ b/etc/adminhtml/system/customer.xml
@@ -11,7 +11,7 @@
         <field id="customer_identity_attribute_code" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="30" translate="label" type="text">
             <label>Customer Identity (CPF/CNPJ) Attribute</label>
             <config_path>payment/braspag_pagador_creditcard/customer_identity_attribute_code</config_path>
-            <comment>object from \Magento\Quote\Model\Quote</comment>
+            <comment>Attribute sequence lookup Quote->BillingAddress and Quote</comment>
         </field>
         <frontend_model>Webjump\BraspagPagador\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
         <include path="Webjump_BraspagPagador::system/customer/address.xml"/>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -42,6 +42,7 @@
                 <can_initialize>1</can_initialize>
                 <can_use_internal>1</can_use_internal>
                 <create_invoice_on_notification_captured>1</create_invoice_on_notification_captured>
+                <customer_identity_attribute_code>vat_id</customer_identity_attribute_code>
             </braspag_pagador_creditcard>
             <braspag_pagador_creditcardtoken>
                 <active>1</active>


### PR DESCRIPTION
Making identity attribute compatible with guest checkout getting the attribute from quote billing address and if it fails to quote.

Executed Manual Test Scenarios
- Guest Checkout Shipping and Billing Same Address
- Guest Checkout Shipping and Billing Different Address
- Registered Customer Shipping and Billing Same Address
- Registered Customer Shipping and Billing Different Address
- Registered Customer New Billing Address
