### PR TITLE
Get store scope config when antifraud capture the invoice

### DIFF
--- a/Gateway/Transaction/Base/Config/AbstractConfig.php
+++ b/Gateway/Transaction/Base/Config/AbstractConfig.php
@@ -53,7 +53,7 @@ abstract class AbstractConfig
         return $this;
     }
 
-    public function getConfig()
+    protected function getConfig()
     {
         return $this->getContext()->getConfig();
     }

--- a/Gateway/Transaction/Base/Config/AbstractConfig.php
+++ b/Gateway/Transaction/Base/Config/AbstractConfig.php
@@ -53,7 +53,7 @@ abstract class AbstractConfig
         return $this;
     }
 
-    protected function getConfig()
+    public function getConfig()
     {
         return $this->getContext()->getConfig();
     }

--- a/Gateway/Transaction/Base/Config/Config.php
+++ b/Gateway/Transaction/Base/Config/Config.php
@@ -13,13 +13,21 @@ namespace Webjump\BraspagPagador\Gateway\Transaction\Base\Config;
  */
 class Config extends AbstractConfig implements ConfigInterface
 {
-	public function getMerchantId()
+	public function getMerchantId($scopeId = null, $scopeType = \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
 	{
+		if (!empty($scopeId)) {
+			return $this->getConfig()->getValue(self::CONFIG_XML_BRASPAG_PAGADOR_GLOBAL_MERCHANT_ID, $scopeType, $scopeId);
+		}
+
 		return $this->_getConfig(self::CONFIG_XML_BRASPAG_PAGADOR_GLOBAL_MERCHANT_ID);
 	}
 
-	public function getMerchantKey()
+	public function getMerchantKey($scopeId = null, $scopeType = \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
 	{
+		if (!empty($scopeId)) {
+			return $this->getConfig()->getValue(self::CONFIG_XML_BRASPAG_PAGADOR_GLOBAL_MERCHANT_KEY, $scopeType, $scopeId);
+		}
+
 		return $this->_getConfig(self::CONFIG_XML_BRASPAG_PAGADOR_GLOBAL_MERCHANT_KEY);
 	}
 

--- a/Gateway/Transaction/CreditCard/Resource/Capture/Request.php
+++ b/Gateway/Transaction/CreditCard/Resource/Capture/Request.php
@@ -32,12 +32,20 @@ class Request implements BraspaglibRequestInterface, BraspagMagentoRequestInterf
 
     public function getMerchantId()
     {
-        return $this->getConfig()->getMerchantId();
+        return $this->getConfig()->getConfig()->getValue(
+            \Webjump\BraspagPagador\Gateway\Transaction\Base\Config\ConfigInterface::CONFIG_XML_BRASPAG_PAGADOR_GLOBAL_MERCHANT_ID,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+            $this->getOrderAdapter()->getStoreId()
+        );
     }
 
     public function getMerchantKey()
     {
-        return $this->getConfig()->getMerchantKey();
+        return $this->getConfig()->getConfig()->getValue(
+            \Webjump\BraspagPagador\Gateway\Transaction\Base\Config\ConfigInterface::CONFIG_XML_BRASPAG_PAGADOR_GLOBAL_MERCHANT_KEY,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+            $this->getOrderAdapter()->getStoreId()
+        );
     }
 
     public function isTestEnvironment()

--- a/Gateway/Transaction/CreditCard/Resource/Capture/Request.php
+++ b/Gateway/Transaction/CreditCard/Resource/Capture/Request.php
@@ -32,20 +32,16 @@ class Request implements BraspaglibRequestInterface, BraspagMagentoRequestInterf
 
     public function getMerchantId()
     {
-        return $this->getConfig()->getConfig()->getValue(
-            \Webjump\BraspagPagador\Gateway\Transaction\Base\Config\ConfigInterface::CONFIG_XML_BRASPAG_PAGADOR_GLOBAL_MERCHANT_ID,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
-            $this->getOrderAdapter()->getStoreId()
-        );
+        $storeId = $this->getOrderAdapter()->getStoreId();
+
+        return $this->getConfig()->getMerchantId($storeId);
     }
 
     public function getMerchantKey()
     {
-        return $this->getConfig()->getConfig()->getValue(
-            \Webjump\BraspagPagador\Gateway\Transaction\Base\Config\ConfigInterface::CONFIG_XML_BRASPAG_PAGADOR_GLOBAL_MERCHANT_KEY,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
-            $this->getOrderAdapter()->getStoreId()
-        );
+        $storeId = $this->getOrderAdapter()->getStoreId();
+
+        return $this->getConfig()->getMerchantKey($storeId);
     }
 
     public function isTestEnvironment()


### PR DESCRIPTION
The invoice capture didn't have scope, so only the default scope value is sent.