### PR TITLE
Fix AntiFraud Analysys Params

### DIFF
--- a/Gateway/Transaction/CreditCard/Resource/Authorize/Request.php
+++ b/Gateway/Transaction/CreditCard/Resource/Authorize/Request.php
@@ -323,6 +323,10 @@ class Request implements BraspaglibRequestInterface, RequestInterface
      */
     public function getCustomerDeliveryAddressCountry()
     {
+        if (!$this->getShippingAddress()) {
+            return '';
+        }
+
         return 'BRA';
     }
 
@@ -359,6 +363,7 @@ class Request implements BraspaglibRequestInterface, RequestInterface
     public function getPaymentCurrency()
     {
         return 'BRL';
+
     }
 
     /**


### PR DESCRIPTION
Enabling "virtual" and "downloadable" products for Anti Fraud analysys, cleaning text from antifraud adresse and remove country value from Delivery Address when it doesn't exists.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)