### PR TITLE
fix: Creditcard AMEX CVV max length to 4 digits

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/creditcard.js
+++ b/view/frontend/web/js/view/payment/method-renderer/creditcard.js
@@ -78,6 +78,7 @@ define(
 
                 if (
                     this.creditCardType() === 'Cielo-Amex' ||
+                    this.creditCardType() === 'Cielo30-Amex' ||
                     this.creditCardType() === 'CieloSitef-Amex'
                 ){
                     maxlength = 4;


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento 2 Braspag Module. 
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
Bug fix credit card type amex. Max length field cvv set lenght to 4 digits 
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format webjump/magento2-module-braspagador#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Admin: Enable Payment Cielo30-AMEX
2. Go to front-end and select a product and make a order 
3. Select Credit Card Payment
4. Select Card Type Cielo30-Amex
5. Field CVV max lenght is 4 digit

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [x] All automated tests passed successfully (all builds on Travis CI are green)