### PR TITLE
Erro ao abrir o swagger com magento 2.3.2

### DIFF
--- a/Api/Auth3Ds20TokenManagerInterface.php
+++ b/Api/Auth3Ds20TokenManagerInterface.php
@@ -13,7 +13,7 @@ namespace Webjump\BraspagPagador\Api;
 interface Auth3Ds20TokenManagerInterface
 {
     /**
-     * @return array
+     * @return mixed
      */
     public function getToken();
 }

--- a/modman
+++ b/modman
@@ -1,1 +1,0 @@
-. app/code/Webjump/BraspagPagador/

--- a/modman
+++ b/modman
@@ -1,0 +1,1 @@
+. app/code/Webjump/BraspagPagador/


### PR DESCRIPTION
#85
 # Description (*)
Após instalar o módulo Webjump Braspag não é possível acessar o Swagger com a documentação das APIs. [Issue 82](https://github.com/webjump/magento2-module-braspagpagador/issues/82)
### Fixed Issues (if relevant)
Aparece as descrições de rest api da swaggger.
### Manual testing scenarios (*)
 1) Entre em <dominio>/swagger
2) Aparecera as descrições de api.
### Contribution checklist (*)

 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)