### PR TITLE
Creating authentication 3DS20 for Adaptation to the Headless model vi…

### DIFF
--- a/Api/Auth3DS20GetAddressInterface.php
+++ b/Api/Auth3DS20GetAddressInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Api;
+
+use Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface;
+
+/**
+ * Interface Auth3DS20GetAddressInterface
+ *
+ * @package Webjump\BraspagPagador\Api
+ */
+interface Auth3DS20GetAddressInterface
+{
+    /**
+     * @param \Magento\Quote\Api\Data\CartInterface $quote
+     * @return Auth3DS20AddressInformationInterface
+     */
+    public function getAddressData(\Magento\Quote\Api\Data\CartInterface $quote): Auth3DS20AddressInformationInterface;
+}

--- a/Api/Auth3DS20GetCartInterface.php
+++ b/Api/Auth3DS20GetCartInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Api;
+
+use Webjump\BraspagPagador\Data\Auth3DS20CartInformationInterface;
+
+/**
+ * Interface Auth3DS20GetCartInterface
+ *
+ * @package Webjump\BraspagPagador\Api
+ */
+interface Auth3DS20GetCartInterface
+{
+    /**
+     * @param \Magento\Quote\Api\Data\CartInterface $quote
+     * @return \Webjump\BraspagPagador\Api\Data\Auth3DS20CartInformationInterface[]
+     */
+    public function getCartData(\Magento\Quote\Api\Data\CartInterface $quote): array;
+}

--- a/Api/Auth3DS20ResultInformationInterface.php
+++ b/Api/Auth3DS20ResultInformationInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Api;
+
+use Webjump\BraspagPagador\Api\Data\Auth3DS20InformationInterface;
+
+/**
+ * Interface Auth3DS20ResultInformationInterface
+ *
+ * @package Webjump\BraspagPagador\Api
+ */
+interface Auth3DS20ResultInformationInterface
+{
+    /**
+     * @param int $cartId
+     * @return \Webjump\BraspagPagador\Api\Data\Auth3DS20InformationInterface
+     */
+    public function getInformation(int $cartId): Auth3DS20InformationInterface;
+
+}

--- a/Api/Auth3DS20UserAccountInterface.php
+++ b/Api/Auth3DS20UserAccountInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Api;
+
+use Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface;
+
+/**
+ * Interface Auth3DS20UserAccountInterface
+ *
+ * @package Webjump\BraspagPagador\Api
+ */
+interface Auth3DS20UserAccountInterface
+{
+    /**
+     * @param \Magento\Quote\Api\Data\CartInterface $quote
+     * @return Auth3DS20UserAccountInformationInterface
+     */
+    public function getUserAccount(\Magento\Quote\Api\Data\CartInterface $quote): Auth3DS20UserAccountInformationInterface;
+}

--- a/Api/Data/Auth3DS20AddressInformationInterface.php
+++ b/Api/Data/Auth3DS20AddressInformationInterface.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Api\Data;
+
+/**
+ * Interface Auth3DS20AddressInformationInterface
+ *
+ * @package Webjump\BraspagPagador\Api\Data
+ */
+Interface Auth3DS20AddressInformationInterface
+{
+    const BPMPI_BILLTO_PHONENUMBER = 'bpmpi_billto_phonenumber';
+
+    const BPMPI_BILLTO_CUSTOMERID = 'bpmpi_billto_customerid';
+
+    const BPMPI_BILLTO_EMAIL = 'bpmpi_billto_email';
+
+    const BPMPI_BILLTO_STREET1 = 'bpmpi_billto_street1';
+
+    const BPMPI_BILLTO_STREET2 = 'bpmpi_billto_street2';
+
+    const BPMPI_BILLTO_CITY = 'bpmpi_billto_city';
+
+    const BPMPI_BILLTO_STATE= 'bpmpi_billto_state';
+
+    const BPMPI_BILLTO_ZIPCODE = 'bpmpi_billto_zipcode';
+
+    const BPMPI_BILLTO_COUNTRY = 'bpmpi_billto_country';
+
+    const BPMPI_SHIPTO_SAMEASBILLTO = 'bpmpi_shipto_sameasbillto';
+
+    const BPMPI_SHIPTO_ADDRESSEE = 'bpmpi_shipto_addressee';
+
+    const BPMPI_SHIPTO_PHONENUMBER = 'bpmpi_shipto_phonenumber';
+
+    const BPMPI_SHIPTO_EMAIL = 'bpmpi_shipto_email';
+
+    const BPMPI_SHIPTO_STREET1 = 'bpmpi_shipto_street1';
+
+    const BPMPI_SHIPTO_STREET2 = 'bpmpi_shipto_street2';
+
+    const BPMPI_SHIPTO_CITY = 'bpmpi_shipto_city';
+
+    const BPMPI_SHIPTO_STATE = 'bpmpi_shipto_state';
+
+    const BPMPI_SHIPTO_ZIPCODE = 'bpmpi_shipto_zipcode';
+
+    const BPMPI_SHIPTO_COUNTRY = 'bpmpi_shipto_country';
+
+    /**
+     * @return string
+     */
+    public function getBpmpiBilltoPhoneNumber(): string;
+
+    /**
+     * @param string $bpmpiBilltoPhoneNumber
+     * @return void;
+     */
+    public function setBpmpiBilltoPhoneNumber(string $bpmpiBilltoPhoneNumber): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiBilltoCustomerid(): string;
+
+    /**
+     * @param string $bpmpiBilltoCustomerid
+     * @return void;
+     */
+    public function setBpmpiBilltoCustomerid(string $bpmpiBilltoCustomerid ): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiBilltoEmail(): string;
+
+    /**
+     * @param string $bpmpiBilltoEmail
+     * @return void;
+     */
+    public function setBpmpiBilltoEmail(string $bpmpiBilltoEmail): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiBilltoStreet1(): string;
+
+    /**
+     * @param string $bpmpiBilltoStreet1
+     * @return void;
+     */
+    public function setBpmpiBilltoStreet1(string $bpmpiBilltoStreet1): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiBilltoStreet2(): string;
+
+    /**
+     * @param string $bpmpiBilltoStreet2
+     * @return void;
+     */
+    public function setBpmpiBilltoStreet2(string $bpmpiBilltoStreet2): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiBilltoCity(): string;
+
+    /**
+     * @param string $bpmpiBilltoCity
+     * @return void;
+     */
+    public function setBpmpiBilltoCity(string $bpmpiBilltoCity): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiBilltoState(): string;
+
+    /**
+     * @param string $bpmpiBilltoState
+     * @return void;
+     */
+    public function setBpmpiBilltoState(string $bpmpiBilltoState): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiBilltoZipcode(): string;
+
+    /**
+     * @param string $bpmpiBilltoZipcode
+     * @return void;
+     */
+    public function setBpmpiBilltoZipcode(string $bpmpiBilltoZipcode): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiBilltoCountry(): string;
+
+    /**
+     * @param string $bpmpiBilltoCountry
+     * @return void;
+     */
+    public function setBpmpiBilltoCountry(string $bpmpiBilltoCountry): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiShiptoSameasbillto(): bool;
+
+    /**
+     * @param string $bpmpiShiptoSameasbillto
+     * @return void;
+     */
+    public function setBpmpiShiptoSameasbillto(bool $bpmpiShiptoSameasbillto ): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiShiptoAddressee(): string;
+
+    /**
+     * @param string $bpmpiShiptoAddressee
+     * @return void;
+     */
+    public function setBpmpiShiptoAddressee(string $bpmpiShiptoAddressee): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiShiptoPhonenumber(): string;
+
+    /**
+     * @param string $bpmpiShiptoPhonenumber
+     * @return void;
+     */
+    public function setBpmpiShiptoPhonenumber(string $bpmpiShiptoPhonenumber ): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiShiptoEmail(): string;
+
+    /**
+     * @param string $bpmpiShiptoEmail
+     * @return void;
+     */
+    public function setBpmpiShiptoEmail(string $bpmpiShiptoEmail): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiShiptoStreet1(): string;
+
+    /**
+     * @param string $bpmpiShiptoStreet1
+     * @return void;
+     */
+    public function setBpmpiShiptoStreet1(string $bpmpiShiptoStreet1 ): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiShiptoStreet2(): string;
+
+    /**
+     * @param string $bpmpiShiptoStreet2
+     * @return void;
+     */
+    public function setBpmpiShiptoStreet2(string $bpmpiShiptoStreet2 ): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiShiptoCity(): string;
+
+    /**
+     * @param string $bpmpiShiptoCity
+     * @return void;
+     */
+    public function setBpmpiShiptoCity(string $bpmpiShiptoCity ): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiShiptoState(): string;
+
+    /**
+     * @param string $bpmpiShiptoState
+     * @return void;
+     */
+    public function setBpmpiShiptoState(string $bpmpiShiptoState): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiShiptoZipcode(): string;
+
+    /**
+     * @param string $bpmpiShiptoZipcode
+     * @return void;
+     */
+    public function setBpmpiShiptoZipcode(string $bpmpiShiptoZipcode): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiShiptoCountry(): string;
+
+    /**
+     * @param string $bpmpiShiptoCountry
+     * @return void;
+     */
+    public function setBpmpiShiptoCountry(string $bpmpiShiptoCountry): void;
+}

--- a/Api/Data/Auth3DS20CartInformationInterface.php
+++ b/Api/Data/Auth3DS20CartInformationInterface.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Api\Data;
+
+/**
+ * Interface Auth3DS20CartInformationInterface
+ *
+ * @package Webjump\BraspagPagador\Api\Data
+ */
+interface Auth3DS20CartInformationInterface
+{
+    const BPMPI_CART_DESCRIPTION= 'bpmpi_cart_description';
+
+    const BPMPI_CART_NAME = 'bpmpi_cart_name';
+
+    const BPMPI_CART_SKU = 'bpmpi_cart_sku';
+
+    const BPMPI_CART_QUANTITY = 'bpmpi_cart_quantity';
+
+    const BPMPI_CART_UNITPRICE = 'bpmpi_cart_unitprice';
+
+    /**
+     * @return string
+     */
+    public function getBpmpiCartDescription(): string;
+
+    /**
+     * @param string $bpmpiCartDescription
+     * @return void
+     */
+    public function setBpmpiCartDescription(string $bpmpiCartDescription): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiCartName(): string;
+
+    /**
+     * @param string $bpmpiCartName
+     * @return void
+     */
+    public function setBpmpiCartName(string $bpmpiCartName): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiCartSku(): string;
+
+    /**
+     * @param string $bpmpiCartSku
+     * @return void
+     */
+    public function setBpmpiCartSku(string $bpmpiCartSku): void;
+
+    /**
+     * @return int
+     */
+    public function getBpmpiCartQuantity(): int;
+
+    /**
+     * @param int $bpmpiCartQuantity
+     * @return void
+     */
+    public function setBpmpiCartQuantity(int $bpmpiCartQuantity ): void;
+
+    /**
+     * @return float
+     */
+    public function getBpmpiCartUnitprice(): float;
+
+    /**
+     * @param float $bpmpiCartUnitprice
+     * @return void
+     */
+    public function setBpmpiCartUnitprice(float $bpmpiCartUnitprice): void;
+}

--- a/Api/Data/Auth3DS20InformationInterface.php
+++ b/Api/Data/Auth3DS20InformationInterface.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Api\Data;
+
+use Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface;
+
+/**
+ * Interface Auth3DS20InformationInterface
+ *
+ * @package Webjump\BraspagPagador\Api\Data
+ */
+interface Auth3DS20InformationInterface
+{
+    const BPMPI_DEBIT_AUTH = 'bpmpi_debit_auth';
+
+    const BPMPI_CREDIT_AUTH = 'bpmpi_credit_auth';
+
+    const BPMPI_DEBIT_AUTH_NOTIFYONLY = 'bpmpi_debit_auth_notifyonly';
+
+    const BPMPI_CREDIT_AUTH_NOTIFYONLY = 'bpmpi_credit_auth_notifyonly';
+
+    const BPMPI_TOTALAMOUNT = 'bpmpi_totalamount';
+
+    const BPMPI_CURRENCY = 'bpmpi_currency';
+
+    const BPMPI_ORDERNUMBER = 'bpmpi_ordernumber';
+
+    const BPMPI_TRANSACTION_MODE = 'bpmpi_transaction_mode';
+
+    const BPMPI_MERCHANT_URL = 'bpmpi_merchant_url';
+
+    const BPMPI_ADDRESSES_DATA = 'addresses_data';
+
+    const BPMPI_CART_DATA = 'cart_data';
+
+    const BPMPI_USER_ACCOUNT = 'user_account';
+
+    /**
+     * @return bool
+     */
+    public function getBpmpiDebitAuth(): bool;
+
+    /**
+     * @param bool $bpmpiDebitAuth
+     * @return void;
+     */
+    public function setBpmpiDebitAuth(bool $bpmpiDebitAuth): void;
+
+    /**
+     * @return bool
+     */
+    public function getBpmpiCreditAuth(): bool;
+
+    /**
+     * @param bool $bpmpiCreditAuth
+     * @return void
+     */
+    public function setBpmpiCreditAuth(bool $bpmpiCreditAuth): void;
+
+    /**
+     * @return bool
+     */
+    public function getBpmpiDebitAuthNotifyonly(): bool;
+
+    /**
+     * @param bool $bpmpiAuthDebitNotifyonly
+     * @return void;
+     */
+    public function setBpmpiDebitAuthNotifyonly(bool $bpmpiAuthDebitNotifyonly): void;
+
+    /**
+     * @return bool
+     */
+    public function getBpmpiCreditAuthNotifyonly(): bool;
+
+    /**
+     * @param bool $bpmpiAuthCreditNotifyonly
+     * @return void;
+     */
+    public function setBpmpiCreditAuthNotifyonly(bool $bpmpiAuthCreditNotifyonly): void;
+
+    /**
+     * @return float
+     */
+    public function getBpmpiTotalamount(): float;
+
+    /**
+     * @return float
+     */
+    public function setBpmpiTotalamount(float $bpmpiTotalAmount): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiCurrency(): string;
+
+    /**
+     * @return string
+     */
+    public function setBpmpiCurrency(string $bpmpiCurrency): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiOrdernumber(): string;
+
+    /**
+     * @return string
+     */
+    public function setBpmpiOrdernumber(string $bpmpiOrderNumber): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiTransactionMode(): string;
+
+    /**
+     * @return string
+     */
+    public function setBpmpiTransactionMode(string $bpmpiTransactionMode): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiMerchantUrl(): string;
+
+    /**
+     * @param string $bpmpiMerchantUrl
+     * @return void
+     */
+    public function setBpmpiMerchantUrl(string $bpmpiMerchantUrl): void;
+
+    /**
+     * @return \Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface
+     */
+    public function getAddressData(): \Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface;
+
+    /**
+     * @param \Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface $addressesData
+     * @return void
+     */
+    public function setAddressesData(\Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface $addressesData): void;
+
+    /**
+     * @return \Webjump\BraspagPagador\Api\Data\Auth3DS20CartInformationInterface[]
+     */
+    public function getCartData(): array;
+
+    /**
+     * @param array $cartData
+     * @return void
+     */
+    public function setCartData(array $cartData): void;
+
+    /**
+     * @return \Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface
+     */
+    public function getUserAccount(): \Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface;
+
+    /**
+     * @param \Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface $userAccount
+     * @return void
+     */
+    public function setUserAccount(\Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface $userAccount): void;
+}

--- a/Api/Data/Auth3DS20UserAccountInformationInterface.php
+++ b/Api/Data/Auth3DS20UserAccountInformationInterface.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Api\Data;
+
+/**
+ * Interface Auth3DS20UserAccountInformationInterface
+ *
+ * @package Webjump\BraspagPagador\Api\Data
+ */
+interface Auth3DS20UserAccountInformationInterface
+{
+    const BPMPI_USERACCOUNT_GUEST = 'bpmpi_useraccount_guest';
+
+    const BPMPI_USERACCOUNT_CREATEDDATE = 'bpmpi_useraccount_createddate';
+
+    const BPMPI_USERACCOUNT_CHANGEDDATE = 'bpmpi_useraccount_changeddate';
+
+    const BPMPI_USERACCOUNT_AUTHENTICATIONMETHOD = 'bpmpi_useraccount_authenticationmethod';
+
+    const BPMPI_USERACCOUNT_AUTHENTICATIONPROTOCOL = 'bpmpi_useraccount_authenticationprotocol';
+
+    const BPMPI_DEVICE_IPADDRESS = 'bpmpi_device_ipaddress';
+
+    /**
+     * @return bool
+     */
+    public function getBpmpiUseraccountGuest(): bool;
+
+    /**
+     * @param bool $bpmpiUseraccountGuest
+     * @return void
+     */
+    public function setBpmpiUseraccountGuest(bool $bpmpiUseraccountGuest): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiUseraccountCreateddate(): string;
+
+    /**
+     * @param string $bpmpiUseraccountCreateddate
+     * @return void
+     */
+    public function setBpmpiUseraccountCreateddate(string $bpmpiUseraccountCreateddate): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiUseraccountChangeddate(): string;
+
+    /**
+     * @param string $bpmpiUseraccountChangeddate
+     * @return void
+     */
+    public function setBpmpiUseraccountChangeddate(string $bpmpiUseraccountChangeddate): void;
+
+    /**
+     * @return int
+     */
+    public function getBpmpiUseraccountAuthenticationmethod(): int;
+
+    /**
+     * @param int $bpmpiUseraccountAuthenticationmethod
+     * @return void
+     */
+    public function setBpmpiUseraccountAuthenticationmethod(int $bpmpiUseraccountAuthenticationmethod): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiUseraccountAuthenticationprotocol(): string;
+
+    /**
+     * @param string $bpmpiUseraccountAuthenticationprotocol
+     * @return void
+     */
+    public function setBpmpiUseraccountAuthenticationprotocol(string $bpmpiUseraccountAuthenticationprotocol): void;
+
+    /**
+     * @return string
+     */
+    public function getBpmpiDeviceIpaddress(): string;
+
+    /**
+     * @param string $bpmpiDeviceIpaddress
+     * @return void
+     */
+    public function setBpmpiDeviceIpaddress(string $bpmpiDeviceIpaddress): void;
+}

--- a/Model/Auth3DS20/ConfigUrl.php
+++ b/Model/Auth3DS20/ConfigUrl.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br Copyright
+ *
+ * @link        http://www.webjump.com.br
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Model\Auth3DS20;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+
+class ConfigUrl
+{
+    const VALUE_URL = 'web/secure/base_url';
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * ConfigUrl constructor.
+     *
+     * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(ScopeConfigInterface $scopeConfig)
+    {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Get 'web/unsecure/base_url'
+     *
+     * @return mixed
+     */
+    public function getValueUrl()
+    {
+        return $this->scopeConfig->getValue(self::VALUE_URL);
+    }
+}

--- a/Model/Auth3DS20AddressInformation.php
+++ b/Model/Auth3DS20AddressInformation.php
@@ -1,0 +1,327 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Model;
+
+use Magento\Framework\Model\AbstractExtensibleModel;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface;
+
+/**
+ * Class Auth3DS20AddressInformation
+ *
+ * @package Webjump\BraspagPagador\Model
+ */
+class Auth3DS20AddressInformation extends AbstractExtensibleModel implements Auth3DS20AddressInformationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiBilltoPhoneNumber(): string
+    {
+        return (string)$this->getData(self::BPMPI_BILLTO_PHONENUMBER);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiBilltoPhoneNumber(string $bpmpiBilltoPhoneNumber): void
+    {
+        $this->setData(self::BPMPI_BILLTO_PHONENUMBER, $bpmpiBilltoPhoneNumber);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiBilltoCustomerid(): string
+    {
+        return (string)$this->getData(self::BPMPI_BILLTO_CUSTOMERID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiBilltoCustomerid(string $bpmpiBilltoCustomerid): void
+    {
+        $this->setData(self::BPMPI_BILLTO_CUSTOMERID, $bpmpiBilltoCustomerid);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiBilltoEmail(): string
+    {
+        return (string)$this->getData(self::BPMPI_BILLTO_EMAIL);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiBilltoEmail(string $bpmpiBilltoEmail): void
+    {
+        $this->setData(self::BPMPI_BILLTO_EMAIL, $bpmpiBilltoEmail);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiBilltoStreet1(): string
+    {
+        return (string)$this->getData(self::BPMPI_BILLTO_STREET1);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiBilltoStreet1(string $bpmpiBilltoStreet1): void
+    {
+        $this->setData(self::BPMPI_BILLTO_STREET1, $bpmpiBilltoStreet1);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiBilltoStreet2(): string
+    {
+        return (string)$this->getData(self::BPMPI_BILLTO_STREET2);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiBilltoStreet2(string $bpmpiBilltoStreet2): void
+    {
+        $this->setData(self::BPMPI_BILLTO_STREET2, $bpmpiBilltoStreet2);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiBilltoCity(): string
+    {
+        return (string)$this->getData(self::BPMPI_BILLTO_CITY);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiBilltoCity(string $bpmpiBilltoCity): void
+    {
+        $this->setData(self::BPMPI_BILLTO_CITY, $bpmpiBilltoCity);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiBilltoState(): string
+    {
+        return (string)$this->getData(self::BPMPI_BILLTO_STATE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiBilltoState(string $bpmpiBilltoState): void
+    {
+        $this->setData(self::BPMPI_BILLTO_STATE, $bpmpiBilltoState);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiBilltoZipcode(): string
+    {
+        return (string)$this->getData(self::BPMPI_BILLTO_ZIPCODE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiBilltoZipcode(string $bpmpiBilltoZipcode): void
+    {
+        $this->setData(self::BPMPI_BILLTO_ZIPCODE, $bpmpiBilltoZipcode);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiBilltoCountry(): string
+    {
+        return (string)$this->getData(self::BPMPI_BILLTO_COUNTRY);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiBilltoCountry(string $bpmpiBilltoCountry): void
+    {
+        $this->setData(self::BPMPI_BILLTO_COUNTRY, $bpmpiBilltoCountry);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiShiptoSameasbillto(): bool
+    {
+        return (bool)$this->getData(self::BPMPI_SHIPTO_SAMEASBILLTO);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiShiptoSameasbillto(bool $bpmpiShiptoSameasbillto): void
+    {
+        $this->setData(self::BPMPI_SHIPTO_SAMEASBILLTO, $bpmpiShiptoSameasbillto);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiShiptoAddressee(): string
+    {
+        return (string)$this->getData(self::BPMPI_SHIPTO_ADDRESSEE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiShiptoAddressee(string $bpmpiShiptoAddressee): void
+    {
+        $this->setData(self::BPMPI_SHIPTO_ADDRESSEE, $bpmpiShiptoAddressee);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiShiptoPhonenumber(): string
+    {
+        return (string)$this->getData(self::BPMPI_SHIPTO_PHONENUMBER);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiShiptoPhonenumber(string $bpmpiShiptoPhonenumber): void
+    {
+        $this->setData(self::BPMPI_SHIPTO_PHONENUMBER, $bpmpiShiptoPhonenumber);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiShiptoEmail(): string
+    {
+        return (string)$this->getData(self::BPMPI_SHIPTO_EMAIL);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiShiptoEmail(string $bpmpiShiptoEmail): void
+    {
+        $this->setData(self::BPMPI_SHIPTO_EMAIL, $bpmpiShiptoEmail);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiShiptoStreet1(): string
+    {
+        return (string)$this->getData(self::BPMPI_SHIPTO_STREET1);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiShiptoStreet1(string $bpmpiShiptoStreet1): void
+    {
+        $this->setData(self::BPMPI_SHIPTO_STREET1, $bpmpiShiptoStreet1);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiShiptoStreet2(): string
+    {
+        return (string)$this->getData(self::BPMPI_SHIPTO_STREET2);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiShiptoStreet2(string $bpmpiShiptoStreet2): void
+    {
+        $this->setData(self::BPMPI_SHIPTO_STREET2, $bpmpiShiptoStreet2);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiShiptoCity(): string
+    {
+        return (string)$this->getData(self::BPMPI_SHIPTO_CITY);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiShiptoCity(string $bpmpiShiptoCity): void
+    {
+        $this->setData(self::BPMPI_SHIPTO_CITY, $bpmpiShiptoCity);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiShiptoState(): string
+    {
+        return (string)$this->getData(self::BPMPI_SHIPTO_STATE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiShiptoState(string $bpmpiShiptoState): void
+    {
+        $this->setData(self::BPMPI_SHIPTO_STATE, $bpmpiShiptoState);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiShiptoZipcode(): string
+    {
+        return (string)$this->getData(self::BPMPI_SHIPTO_ZIPCODE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiShiptoZipcode(string $bpmpiShiptoZipcode): void
+    {
+        $this->setData(self::BPMPI_SHIPTO_ZIPCODE, $bpmpiShiptoZipcode);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiShiptoCountry(): string
+    {
+        return (string)$this->getData(self::BPMPI_SHIPTO_COUNTRY);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiShiptoCountry(string $bpmpiShiptoCountry): void
+    {
+        $this->setData(self::BPMPI_SHIPTO_COUNTRY, $bpmpiShiptoCountry);
+    }
+
+}

--- a/Model/Auth3DS20CartInformation.php
+++ b/Model/Auth3DS20CartInformation.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Model;
+
+use Magento\Framework\Model\AbstractExtensibleModel;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20CartInformationInterface;
+
+/**
+ * Class Auth3DS20CartInformation
+ *
+ * @package Webjump\BraspagPagador\Model
+ */
+class Auth3DS20CartInformation extends AbstractExtensibleModel implements Auth3DS20CartInformationInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiCartDescription(): string
+    {
+        return (string)$this->getData(self::BPMPI_CART_DESCRIPTION);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiCartDescription(string $bpmpiCartDescription): void
+    {
+        $this->setData(self::BPMPI_CART_DESCRIPTION, $bpmpiCartDescription);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiCartName(): string
+    {
+        return (string)$this->getData(self::BPMPI_CART_NAME);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiCartName(string $bpmpiCartName): void
+    {
+        $this->setData(self::BPMPI_CART_NAME, $bpmpiCartName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiCartSku(): string
+    {
+        return (string)$this->getData(self::BPMPI_CART_SKU);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiCartSku(string $bpmpiCartSku): void
+    {
+        $this->setData(self::BPMPI_CART_SKU, $bpmpiCartSku);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiCartQuantity(): int
+    {
+        return (int)$this->getData(self::BPMPI_CART_QUANTITY);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiCartQuantity(int $bpmpiCartQuantity): void
+    {
+        $this->setData(self::BPMPI_CART_QUANTITY, $bpmpiCartQuantity);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiCartUnitprice(): float
+    {
+        return (float)$this->getData(self::BPMPI_CART_UNITPRICE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiCartUnitprice(float $bpmpiCartUnitprice): void
+    {
+        $this->setData(self::BPMPI_CART_UNITPRICE, $bpmpiCartUnitprice);
+    }
+}

--- a/Model/Auth3DS20GetAddress.php
+++ b/Model/Auth3DS20GetAddress.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Model;
+
+use Webjump\BraspagPagador\Api\Auth3DS20GetAddressInterface;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterfaceFactory;
+
+/**
+ * Class Auth3DS20GetAddress
+ *
+ * @package Webjump\BraspagPagador\Model
+ */
+class Auth3DS20GetAddress implements Auth3DS20GetAddressInterface
+{
+    private $addressInformationInterfaceFactory;
+
+    /**
+     * Auth3DS20GetAddress constructor.
+     *
+     * @param Auth3DS20AddressInformationInterfaceFactory $addressInformationInterfaceFactory
+     */
+    public function __construct(Auth3DS20AddressInformationInterfaceFactory $addressInformationInterfaceFactory)
+    {
+        $this->addressInformationInterfaceFactory = $addressInformationInterfaceFactory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAddressData(\Magento\Quote\Api\Data\CartInterface $quote): \Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface
+    {
+        /** @var $auth3DS20AdressInformation Auth3DS20AddressInformationInterface */
+        $auth3DS20AdressInformation = $this->addressInformationInterfaceFactory->create();
+        $auth3DS20AdressInformation->setBpmpiBilltoCity($quote->getBillingAddress()->getCity());
+        $auth3DS20AdressInformation->setBpmpiBilltoEmail($quote->getBillingAddress()->getEmail());
+        $auth3DS20AdressInformation->setBpmpiBilltoCountry($quote->getBillingAddress()->getCountryId());
+        $auth3DS20AdressInformation->setBpmpiBilltoState($quote->getBillingAddress()->getRegionCode());
+        $auth3DS20AdressInformation->setBpmpiBilltoCustomerid((string)$quote->getBillingAddress()->getCustomerId());
+        $auth3DS20AdressInformation->setBpmpiBilltoStreet1(implode(',', $quote->getBillingAddress()->getStreet()));
+        $auth3DS20AdressInformation->setBpmpiBilltoStreet2(implode(',', $quote->getBillingAddress()->getStreet()));
+        $auth3DS20AdressInformation->setBpmpiBilltoZipcode(preg_replace('/[^0-9]/','', $quote->getBillingAddress()->getPostcode()));
+        $auth3DS20AdressInformation->setBpmpiBilltoPhoneNumber(preg_replace('/[^0-9]/','', $quote->getBillingAddress()->getTelephone()));
+        $auth3DS20AdressInformation->setBpmpiShiptoAddressee($quote->getBillingAddress()->getFirstname());
+
+        $auth3DS20AdressInformation->setBpmpiShiptoAddressee($quote->getShippingAddress()->getFirstname());
+        $auth3DS20AdressInformation->setBpmpiShiptoPhonenumber(preg_replace('/[^0-9]/','', $quote->getShippingAddress()->getTelephone()));
+        $auth3DS20AdressInformation->setBpmpiShiptoEmail($quote->getShippingAddress()->getEmail());
+        $auth3DS20AdressInformation->setBpmpiShiptoStreet1(implode(',', $quote->getShippingAddress()->getStreet()));
+        $auth3DS20AdressInformation->setBpmpiShiptoStreet2(implode(',', $quote->getShippingAddress()->getStreet()));
+        $auth3DS20AdressInformation->setBpmpiShiptoPhonenumber(preg_replace('/[^0-9]/','', $quote->getShippingAddress()->getTelephone()));
+        $auth3DS20AdressInformation->setBpmpiShiptoZipcode(preg_replace('/[^0-9]/','', $quote->getShippingAddress()->getPostCode()));
+        $auth3DS20AdressInformation->setBpmpiShiptoCity($quote->getShippingAddress()->getCity());
+        $auth3DS20AdressInformation->setBpmpiShiptoCountry($quote->getShippingAddress()->getCountryId());
+        $auth3DS20AdressInformation->setBpmpiShiptoState($quote->getShippingAddress()->getRegionCode());
+
+        return $auth3DS20AdressInformation;
+    }
+}

--- a/Model/Auth3DS20GetCart.php
+++ b/Model/Auth3DS20GetCart.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Model;
+
+use Magento\Framework\Pricing\Helper\Data as PriceHelper;
+use Webjump\BraspagPagador\Api\Auth3DS20GetCartInterface;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20CartInformationInterface;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20CartInformationInterfaceFactory;
+
+/**
+ * Class Auth3DS20GetCart
+ *
+ * @package Webjump\BraspagPagador\Model
+ */
+class Auth3DS20GetCart implements Auth3DS20GetCartInterface
+{
+    /**
+     * @var
+     */
+    private $cartInformationFactory;
+
+    /**
+     * @var PriceHelper
+     */
+    private $priceHelper;
+
+    /**
+     * Auth3DS20GetCart constructor.
+     * @param Auth3DS20CartInformationInterfaceFactory $cartInformationFactory
+     * @param PriceHelper $priceHelper
+     */
+    public function __construct(
+        Auth3DS20CartInformationInterfaceFactory $cartInformationFactory,
+        PriceHelper $priceHelper
+    ){
+        $this->cartInformationFactory = $cartInformationFactory;
+        $this->priceHelper = $priceHelper;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCartData(\Magento\Quote\Api\Data\CartInterface $quote): array
+    {
+        $result = [];
+        foreach ($quote->getItems() as $item)
+        {
+            $auth3DS20CartInformation = $this->cartItemInformation(
+                $item->getSku(),
+                $item->getName(),
+                $item->getPrice(),
+                $item->getQty()
+
+            );
+
+            $result[] = $auth3DS20CartInformation;
+        }
+
+        return $result;
+    }
+
+    public function cartItemInformation($sku, $name, $price, $qty): Auth3DS20CartInformationInterface
+    {
+        /** @var $auth3DS20CartInformation Auth3DS20CartInformationInterface */
+        $auth3DS20CartInformation = $this->cartInformationFactory->create();
+
+        $auth3DS20CartInformation->setBpmpiCartSku($sku);
+        $auth3DS20CartInformation->setBpmpiCartName($name);
+        $auth3DS20CartInformation->setBpmpiCartUnitprice((float)$this->priceHelper->currency($price, false, false));
+        $auth3DS20CartInformation->setBpmpiCartQuantity((int)$qty);
+
+        return $auth3DS20CartInformation;
+    }
+}
+

--- a/Model/Auth3DS20Information.php
+++ b/Model/Auth3DS20Information.php
@@ -1,0 +1,284 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+namespace Webjump\BraspagPagador\Model;
+
+use Magento\Framework\Api\AttributeValueFactory;
+use Magento\Framework\Api\ExtensionAttributesFactory;
+use Magento\Framework\Model\AbstractExtensibleModel;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20InformationInterface;
+use Webjump\BraspagPagador\Api\Auth3DS20GetAddressInterface;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Webjump\BraspagPagador\Api\Auth3DS20GetCartInterface;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20CartInformationInterface;
+use Webjump\BraspagPagador\Api\Auth3DS20UserAccountInterface;
+
+/**
+ * Class Auth3DS20Information
+ *
+ * @package Webjump\BraspagPagador\Model
+ */
+class Auth3DS20Information extends AbstractExtensibleModel implements Auth3DS20InformationInterface
+{
+    /**
+     * @var Auth3DS20GetAddressInterface
+     */
+    private $auth3DS20AddressInformation;
+
+    /**
+     * @var Auth3DS20GetCartInterface
+     */
+    private $auth3DS20CartInformation;
+
+    /**
+     * @var Auth3DS20CartInformationInterface
+     */
+    private $auth3DS20CartInformationInterface;
+
+    /**
+     * @var Auth3DS20UserAccountInterface
+     */
+    private $auth3DS20UserAccountInformation;
+
+
+    /**
+     * Auth3DS20Information constructor.
+     * @param Context $context
+     * @param \Magento\Framework\Registry $registry
+     * @param ExtensionAttributesFactory $extensionFactory
+     * @param AttributeValueFactory $customAttributeFactory
+     * @param AbstractResource|null $resource
+     * @param \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection
+     * @param array $data
+     * @param Auth3DS20GetAddressInterface $auth3DS20AddressInformation
+     * @param Auth3DS20GetCartInterface $auth3DS20CartInformation
+     * @param Auth3DS20CartInformationInterface $auth3DS20CartInformationInterface
+     * @param Auth3DS20UserAccountInterface $auth3DS20UserAccountInformation
+     */
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Magento\Framework\Registry $registry,
+        ExtensionAttributesFactory $extensionFactory,
+        AttributeValueFactory $customAttributeFactory,
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null, array $data = [],
+        Auth3DS20GetAddressInterface $auth3DS20AddressInformation,
+        Auth3DS20GetCartInterface $auth3DS20CartInformation,
+        Auth3DS20CartInformationInterface $auth3DS20CartInformationInterface,
+        Auth3DS20UserAccountInterface $auth3DS20UserAccountInformation
+
+    ){
+        $this->auth3DS20AddressInformation = $auth3DS20AddressInformation;
+        $this->auth3DS20CartInformation = $auth3DS20CartInformation;
+        $this->auth3DS20CartInformationInterface = $auth3DS20CartInformationInterface;
+        $this->auth3DS20UserAccountInformation = $auth3DS20UserAccountInformation;
+        parent::__construct(
+            $context,
+            $registry,
+            $extensionFactory,
+            $customAttributeFactory,
+            $resource,
+            $resourceCollection,
+            $data);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiDebitAuth(): bool
+    {
+        return (bool)$this->getData(self::BPMPI_DEBIT_AUTH);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiDebitAuth(bool $bpmpiDebitAuth): void
+    {
+        $this->setData(self::BPMPI_DEBIT_AUTH, $bpmpiDebitAuth);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiCreditAuth(): bool
+    {
+        return (bool)$this->getData(self::BPMPI_CREDIT_AUTH);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiCreditAuth(bool $bpmpiCreditAuth): void
+    {
+        $this->setData(self::BPMPI_CREDIT_AUTH, $bpmpiCreditAuth);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiDebitAuthNotifyonly(): bool
+    {
+        return (bool)$this->getData(self::BPMPI_DEBIT_AUTH_NOTIFYONLY);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiDebitAuthNotifyonly(bool $bpmpiAuthDebitNotifyonly): void
+    {
+        $this->setData(self::BPMPI_DEBIT_AUTH_NOTIFYONLY, $bpmpiAuthDebitNotifyonly);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiCreditAuthNotifyonly(): bool
+    {
+        return (bool)$this->getData(self::BPMPI_CREDIT_AUTH_NOTIFYONLY);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiCreditAuthNotifyonly(bool $bpmpiAuthCreditNotifyonly): void
+    {
+        $this->setData(self::BPMPI_CREDIT_AUTH_NOTIFYONLY, $bpmpiAuthCreditNotifyonly);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiTotalamount(): float
+    {
+        return (float)$this->getData(self::BPMPI_TOTALAMOUNT);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiTotalamount(float $bpmpiTotalAmount): void
+    {
+        $this->setData(self::BPMPI_TOTALAMOUNT, $bpmpiTotalAmount);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiCurrency(): string
+    {
+        return (string)$this->getData(self::BPMPI_CURRENCY);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiCurrency(string $bpmpiCurrency): void
+    {
+        $this->setData(self::BPMPI_CURRENCY, $bpmpiCurrency);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiOrderNumber(): string
+    {
+        return (string)$this->getData(self::BPMPI_ORDERNUMBER);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiOrderNumber(string $bpmpiOrderNumber): void
+    {
+        $this->setData(self::BPMPI_ORDERNUMBER, $bpmpiOrderNumber);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiTransactionMode(): string
+    {
+        return (string)$this->getData(self::BPMPI_TRANSACTION_MODE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiTransactionMode(string $bpmpiTransactionMode): void
+    {
+        $this->setData(self::BPMPI_TRANSACTION_MODE, $bpmpiTransactionMode);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiMerchantUrl(): string
+    {
+        return (string)$this->getData(self::BPMPI_MERCHANT_URL);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiMerchantUrl(string $bpmpiTransactionMode): void
+    {
+        $this->setData(self::BPMPI_MERCHANT_URL, $bpmpiTransactionMode);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAddressData(): \Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface
+    {
+        return $this->getData(self::BPMPI_ADDRESSES_DATA);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setAddressesData(\Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface $addressesData): void
+    {
+        $this->setData(self::BPMPI_ADDRESSES_DATA, $addressesData);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCartData(): array
+    {
+        return $this->getData(self::BPMPI_CART_DATA);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setCartData(array $cartData): void
+    {
+        $this->setData(self::BPMPI_CART_DATA, $cartData);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUserAccount(): \Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface
+    {
+        return $this->getData(self::BPMPI_USER_ACCOUNT);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setUserAccount(\Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface $userAccount): void
+    {
+        $this->setData(self::BPMPI_USER_ACCOUNT, $userAccount);
+    }
+}

--- a/Model/Auth3DS20ResultInformation.php
+++ b/Model/Auth3DS20ResultInformation.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Model;
+
+use Webjump\BraspagPagador\Api\Data\Auth3DS20InformationInterface;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20InformationInterfaceFactory;
+use Webjump\BraspagPagador\Gateway\Transaction\CreditCard\Config\Config;
+use Webjump\BraspagPagador\Gateway\Transaction\DebitCard\Config\Config as DebitConfig;
+use Magento\Quote\Model\QuoteRepository;
+use Magento\Framework\Pricing\Helper\Data as PriceHelper;
+use Webjump\BraspagPagador\Api\Auth3DS20GetAddressInterface;
+use Webjump\BraspagPagador\Api\Auth3DS20GetCartInterface;
+use Webjump\BraspagPagador\Api\Auth3DS20UserAccountInterface;
+use Webjump\BraspagPagador\Model\Auth3DS20\ConfigUrl;
+
+/**
+ * Class Auth3DS20ResultInformation
+ *
+ * @package Webjump\BraspagPagador\Model
+ */
+class Auth3DS20ResultInformation implements \Webjump\BraspagPagador\Api\Auth3DS20ResultInformationInterface
+{
+    /**
+     * @var Auth3DS20InformationInterfaceFactory
+     */
+    private $auth3DS20InformationFactory;
+
+    /**
+     * @var Config
+     */
+    private $creditConfig;
+
+    /**
+     * @var DebitConfig
+     */
+    private $debitConfig;
+
+    /**
+     * @var QuoteRepository
+     */
+    private $quoteRepository;
+
+    /**
+     * @var PriceHelper
+     */
+    private $priceHelper;
+
+    /**
+     * @var Auth3DS20GetAddressInterface
+     */
+    private $auth3DS20GetAddress;
+
+    /**
+     * @var Auth3DS20GetCartInterface
+     */
+    private $auth3DS20GetCart;
+
+    /**
+     * @var Auth3DS20UserAccountInterface
+     */
+    private $auth3DS20UserAccount;
+
+    /**
+     * @var ConfigUrl
+     */
+    private $configUrl;
+
+    /**
+     * Auth3DS20ResultInformation constructor.
+     *
+     * @param Auth3DS20InformationInterfaceFactory $auth3DS20InformationFactory
+     * @param Config $creditConfig
+     * @param DebitConfig $debitConfig
+     * @param QuoteRepository $quoteRepository
+     * @param PriceHelper $priceHelper
+     * @param Auth3DS20GetAddressInterface $auth3DS20GetAddress
+     * @param Auth3DS20GetCartInterface $auth3DS20GetCart
+     * @param Auth3DS20UserAccountInterface $auth3DS20UserAccount
+     * @param ConfigUrl $configUrl
+     */
+    public function __construct(
+        Auth3DS20InformationInterfaceFactory $auth3DS20InformationFactory,
+        Config $creditConfig,
+        DebitConfig $debitConfig,
+        QuoteRepository $quoteRepository,
+        PriceHelper $priceHelper,
+        Auth3DS20GetAddressInterface $auth3DS20GetAddress,
+        Auth3DS20GetCartInterface $auth3DS20GetCart,
+        Auth3DS20UserAccountInterface $auth3DS20UserAccount,
+        ConfigUrl $configUrl
+    ){
+        $this->auth3DS20InformationFactory = $auth3DS20InformationFactory;
+        $this->creditConfig = $creditConfig;
+        $this->debitConfig = $debitConfig;
+        $this->quoteRepository = $quoteRepository;
+        $this->priceHelper = $priceHelper;
+        $this->auth3DS20GetAddress = $auth3DS20GetAddress;
+        $this->auth3DS20GetCart = $auth3DS20GetCart;
+        $this->auth3DS20UserAccount = $auth3DS20UserAccount;
+        $this->configUrl = $configUrl;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getInformation(int $cartId): \Webjump\BraspagPagador\Api\Data\Auth3DS20InformationInterface
+    {
+        /** @var $auth3DS20Information Auth3DS20InformationInterface */
+        $auth3DS20Information = $this->auth3DS20InformationFactory->create();
+        $quote = $this->quoteRepository->get($cartId);
+
+        $auth3DS20Information->setBpmpiCreditAuthNotifyonly($this->creditConfig->isAuth3Ds20MCOnlyNotifyActive());
+        $auth3DS20Information->setBpmpiDebitAuth($this->debitConfig->isAuth3Ds20Active());
+        $auth3DS20Information->setBpmpiCreditAuthNotifyonly($this->creditConfig->isAuth3Ds20MCOnlyNotifyActive());
+        $auth3DS20Information->setBpmpiDebitAuthNotifyonly($this->debitConfig->isAuth3Ds20MCOnlyNotifyActive());
+        $auth3DS20Information->setBpmpiCurrency('BRL');
+        $auth3DS20Information->setBpmpiMerchantUrl($this->configUrl->getValueUrl());
+        $auth3DS20Information->setBpmpiTotalAmount($this->priceHelper->currency($quote->getGrandTotal(),false, false));
+        $auth3DS20Information->setBpmpiOrderNumber($quote->getEntityId());
+        $auth3DS20Information->setBpmpiTransactionMode('S');
+
+        $addressData = $this->auth3DS20GetAddress->getAddressData($quote);
+        $auth3DS20Information->setAddressesData($addressData);
+
+        $authCartData = $this->auth3DS20GetCart->getCartData($quote);
+        $auth3DS20Information->setCartData($authCartData);
+
+        $userAccount = $this->auth3DS20UserAccount->getUserAccount($quote);
+        $auth3DS20Information->setUserAccount($userAccount);
+
+        return $auth3DS20Information;
+    }
+}

--- a/Model/Auth3DS20UserAccount.php
+++ b/Model/Auth3DS20UserAccount.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Model;
+
+use Webjump\BraspagPagador\Api\Auth3DS20UserAccountInterface;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface;
+use Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterfaceFactory;
+
+/**
+ * Class Auth3DS20UserAccount
+ *
+ * @package Webjump\BraspagPagador\Model
+ */
+class Auth3DS20UserAccount implements Auth3DS20UserAccountInterface
+{
+    /**
+     * @var Auth3DS20UserAccountInformationInterfaceFactory
+     */
+    private $userAccountInformationFactory;
+
+    /**
+     * Auth3DS20UserAccount constructor.
+     * @param Auth3DS20UserAccountInformationInterfaceFactory $userAccountInformationFactory
+     */
+    public function __construct(
+        Auth3DS20UserAccountInformationInterfaceFactory $userAccountInformationFactory
+    ){
+        $this->userAccountInformationFactory = $userAccountInformationFactory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUserAccount(\Magento\Quote\Api\Data\CartInterface $quote): \Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface
+    {
+        /** @var $auth3DS20UserAccount Auth3DS20UserAccountInformationInterface */
+        $auth3DS20UserAccount = $this->userAccountInformationFactory->create();
+
+        $auth3DS20UserAccount->setBpmpiUseraccountCreateddate($quote->getCreatedAt());
+//       $auth3DS20UserAccount->setBpmpiUseraccountGuest($quote->getCustomerIsGuest());
+        $auth3DS20UserAccount->setBpmpiUseraccountAuthenticationmethod(02);
+        $auth3DS20UserAccount->setBpmpiUseraccountChangeddate($quote->getUpdatedAt());
+        $auth3DS20UserAccount->setBpmpiDeviceIpaddress($quote->getRemoteIp());
+
+        return $auth3DS20UserAccount;
+    }
+}

--- a/Model/Auth3DS20UserAccountInformation.php
+++ b/Model/Auth3DS20UserAccountInformation.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @author      Webjump Core Team <dev@webjump.com.br>
+ * @copyright   2020 Webjump (http://www.webjump.com.br)
+ * @license     http://www.webjump.com.br  Copyright
+ * @link        http://www.webjump.com.br
+ */
+
+declare(strict_types=1);
+
+namespace Webjump\BraspagPagador\Model;
+
+use Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface;
+use Magento\Framework\Model\AbstractExtensibleModel;
+
+/**
+ * Class Auth3DS20UserAccountInformation
+ * 
+ * @package Webjump\BraspagPagador\Model
+ */
+class Auth3DS20UserAccountInformation extends AbstractExtensibleModel implements Auth3DS20UserAccountInformationInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiUseraccountGuest(): bool
+    {
+        return (bool)$this->getData(self::BPMPI_USERACCOUNT_GUEST);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiUseraccountGuest(bool $bpmpiUseraccountGuest): void
+    {
+        $this->setData(self::BPMPI_USERACCOUNT_GUEST, $bpmpiUseraccountGuest);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiUseraccountCreateddate(): string
+    {
+        return (string)$this->getData(self::BPMPI_USERACCOUNT_CREATEDDATE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiUseraccountCreateddate(string $bpmpiUseraccountCreateddate): void
+    {
+        $this->setData(self::BPMPI_USERACCOUNT_CREATEDDATE, $bpmpiUseraccountCreateddate);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiUseraccountChangeddate(): string
+    {
+        return (string)$this->getData(self::BPMPI_USERACCOUNT_CHANGEDDATE);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiUseraccountChangeddate(string $bpmpiUseraccountChangeddate): void
+    {
+        $this->setData(self::BPMPI_USERACCOUNT_CHANGEDDATE, $bpmpiUseraccountChangeddate);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiUseraccountAuthenticationMethod(): int
+    {
+        return (int)$this->getData(self::BPMPI_USERACCOUNT_AUTHENTICATIONMETHOD);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiUseraccountAuthenticationMethod(int $bpmpiUseraccountAuthenticationmethod): void
+    {
+        $this->setData(self::BPMPI_USERACCOUNT_AUTHENTICATIONMETHOD, $bpmpiUseraccountAuthenticationmethod);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiUseraccountAuthenticationprotocol(): string
+    {
+        return (string)$this->getData(self::BPMPI_USERACCOUNT_AUTHENTICATIONPROTOCOL);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiUseraccountAuthenticationprotocol(string $bpmpiUseraccountAuthenticationprotocol): void
+    {
+        $this->setData(self::BPMPI_USERACCOUNT_AUTHENTICATIONPROTOCOL, $bpmpiUseraccountAuthenticationprotocol);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getBpmpiDeviceIpaddress(): string
+    {
+        return (string)$this->getData(self::BPMPI_DEVICE_IPADDRESS);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setBpmpiDeviceIpaddress(string $bpmpiDeviceIpaddress): void
+    {
+        $this->setData(self::BPMPI_DEVICE_IPADDRESS, $bpmpiDeviceIpaddress);
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -45,6 +45,15 @@
     <preference for="Webjump\BraspagPagador\Api\CardTokenManagerInterface" type="Webjump\BraspagPagador\Model\CardTokenManager" />
     <preference for="Webjump\BraspagPagador\Api\SplitManagerInterface" type="Webjump\BraspagPagador\Model\SplitManager" />
 
+    <preference for="Webjump\BraspagPagador\Api\Data\Auth3DS20InformationInterface" type="Webjump\BraspagPagador\Model\Auth3DS20Information" />
+    <preference for="Webjump\BraspagPagador\Api\Auth3DS20ResultInformationInterface" type="Webjump\BraspagPagador\Model\Auth3DS20ResultInformation" />
+    <preference for="Webjump\BraspagPagador\Api\Data\Auth3DS20AddressInformationInterface" type="Webjump\BraspagPagador\Model\Auth3DS20AddressInformation" />
+    <preference for="Webjump\BraspagPagador\Api\Auth3DS20GetAddressInterface" type="Webjump\BraspagPagador\Model\Auth3DS20GetAddress" />
+    <preference for="Webjump\BraspagPagador\Api\Data\Auth3DS20CartInformationInterface" type="Webjump\BraspagPagador\Model\Auth3DS20CartInformation" />
+    <preference for="Webjump\BraspagPagador\Api\Auth3DS20GetCartInterface" type="Webjump\BraspagPagador\Model\Auth3DS20GetCart" />
+    <preference for="Webjump\BraspagPagador\Api\Data\Auth3DS20UserAccountInformationInterface" type="Webjump\BraspagPagador\Model\Auth3DS20UserAccountInformation" />
+    <preference for="Webjump\BraspagPagador\Api\Auth3DS20UserAccountInterface" type="Webjump\BraspagPagador\Model\Auth3DS20UserAccount" />
+
     <type name="Webjump\BraspagPagador\Gateway\Transaction\Base\Config\Context">
         <arguments>
             <argument name="session" xsi:type="object">\Magento\Checkout\Model\Session</argument>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -50,4 +50,14 @@
         </resources>
     </route>
 
+    <route url="/V1/braspag/auth3ds20/data" method="GET">
+        <service class="Webjump\BraspagPagador\Api\Auth3DS20ResultInformationInterface" method="getInformation"/>
+        <resources>
+            <resource ref="self" />
+        </resources>
+        <data>
+            <parameter name="cartId" force="true">%cart_id%</parameter>
+        </data>
+    </route>
+
 </routes>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento 2 Braspag Module. 
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Creation of 3DS 2.0 Authentication, adapting to the Headless model via REST API. Allows the possibility where the customer finalizes an order using 3DS 2.0 Authentication for Credit and Debit with Front communicating with the Backend via REST API.
-->

### Fixed Issues (if relevant)
<!---
  There was no error correction
-->
1. webjump/magento2-module-braspagador#<issue_number>: Issue title
2. ...

### Manual testing scenarios (*)
<!--- 
   1. To perform the test, an api query tool is required
    Example: Postman
   2. It is necessary to carry out the customer's authentication token using the endpoint 
       curl -X POST "https://magento.host/index.php/rest/V1/integration/customer/token" \
                 -H "Content-Type:application/json" \
                  -d '{"username":"customer@example.com", "password":"customer_password"}'
    3. The customer must have an active cart.
    4. When the customer proceeds to checkout, request the API
            endpoint:   
       curl -X GET \ https://STORE_ADDRESS/rest/STORE_VIEW/V1/braspag/auth3ds20/data \
                        -H 'Content-Type: application/json' \ 
                        -H 'Authorization: Bearer <admin_token> '

-->
1. ...
2. ...

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)